### PR TITLE
Remove target attribute from theme link

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -17,7 +17,7 @@
 		<div class="site-info">
 			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'popper' ) ); ?>"><?php printf( esc_html__( 'Proudly powered by %s', 'popper' ), 'WordPress' ); ?></a>
 			<span class="sep"> | </span>
-			<?php printf( esc_html__( 'Theme: %1$s', 'popper' ), '<a href="https://wordpress.org/themes/popper/" target="_none"	rel="nofollow">Popper</a>' ); ?>
+			<?php printf( esc_html__( 'Theme: %1$s', 'popper' ), '<a href="https://wordpress.org/themes/popper/" rel="nofollow">Popper</a>' ); ?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
 </div><!-- #page -->


### PR DESCRIPTION
Since `target="_self"` seems like the sensible target attribute to use and the default value, using a target attribute seems redundant after all. 
Fixes #25 