### PR TITLE
Add „Tested up to“ and „Required PHP“, update tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://mor10.com/popper/
 Author: Morten Rand-Hendriksen
 Author URI: http://lynda.com/mor10
 Description: Designed and built around three basic principles - acccessibility, mobile- and touch friendly design, and content in focus - Popper is a great option whether you are building a site, a portfolio, or a blog. The header is fully customizable with colors and background images, the site icon appears as the home button in the top left-hand corner, the menu is easily available in the bottom left-hand corner on mobile devices, and you have the option of displaying widgets at the bottom, or to the left or right. The theme also comes with custom widgets for Recent Posts and Recent Comments.
-Requires at least: 4.4
+Requires at least: 4.1
 Tested up to: 5.6
 Requires PHP: 5.6
 Version: 1.0.2

--- a/style.css
+++ b/style.css
@@ -4,11 +4,14 @@ Theme URI: http://mor10.com/popper/
 Author: Morten Rand-Hendriksen
 Author URI: http://lynda.com/mor10
 Description: Designed and built around three basic principles - acccessibility, mobile- and touch friendly design, and content in focus - Popper is a great option whether you are building a site, a portfolio, or a blog. The header is fully customizable with colors and background images, the site icon appears as the home button in the top left-hand corner, the menu is easily available in the bottom left-hand corner on mobile devices, and you have the option of displaying widgets at the bottom, or to the left or right. The theme also comes with custom widgets for Recent Posts and Recent Comments.
+Requires at least: 4.4
+Tested up to: 5.6
+Requires PHP: 5.6
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: popper
-Tags: accessibility-ready, light, one-column, two-columns, left-sidebar, right-sidebar, responsive-layout, custom-colors, custom-header, custom-menu, featured-images, theme-options, threaded-comments, translation-ready
+Tags: accessibility-ready, one-column, two-columns, left-sidebar, right-sidebar, custom-colors, custom-header, custom-menu, featured-images, theme-options, threaded-comments, translation-ready
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.


### PR DESCRIPTION
Fixes a couple of issues, described in #19.

I added the required information regarding the minimum supported WP and PHP version and tested WP version.
Regarding those values: 4.4 is the oldest version I was able to test Popper with, might work on older versions as well, I didn't deem it important enough to further inspect this, since the market share <4.9 is rather small.
Similar to a recent discussion regarding Antispam Bees min PHP version, 5.6 seems like the sensible option here.

The two removed tags are considered as deprecated.
